### PR TITLE
close mysql stmt.  …

### DIFF
--- a/client_store.go
+++ b/client_store.go
@@ -75,6 +75,11 @@ func (s *ClientStore) initTable() error {
 	if err != nil {
 		return err
 	}
+
+	defer func() {
+		stmt.Close()
+	}()
+
 	_, err = stmt.Exec()
 	if err != nil {
 		return err


### PR DESCRIPTION
no doing close  may cause the error : Can’t create more than max_prepared_stmt_count statements (current value: 16382)